### PR TITLE
Inject into `{{content-for 'app'}}` to avoid CSP issues.

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ module.exports = {
     this.options = getOptions(app, app.options['defeatureify']);
   },
   contentFor: function(type, config) {
-    if(this.app.env === 'development' && type === 'head') {
+    if(this.app.env === 'development' && type === 'app') {
       return insertContent(this.options);
     }
     return '';

--- a/lib/insert-features.js
+++ b/lib/insert-features.js
@@ -1,6 +1,5 @@
 function featuresPrefix(namespace) {
   var prefix = [
-    '<script>',
     '' + namespace + ' = {};',
     '' + namespace + '.FEATURES = {'
   ];
@@ -19,8 +18,7 @@ function featuresSuffix(namespace) {
 
   var suffix = [
     '};',
-    isEnabled(),
-    '</script>'
+    isEnabled()
   ];
 
   return suffix.join('');

--- a/tests/insert-features-test.js
+++ b/tests/insert-features-test.js
@@ -1,7 +1,7 @@
 var insertFeatures = require('../lib/insert-features');
 
 exports.testInsertFeaturesWithOneFeature = function(test) {
-  var expected = '<script>TEST = {};TEST.FEATURES = {"test":true};TEST.FEATURES.isEnabled = function(feature) {return this[feature];};</script>';
+  var expected = 'TEST = {};TEST.FEATURES = {"test":true};TEST.FEATURES.isEnabled = function(feature) {return this[feature];};';
   var options = {
     namespace: 'TEST',
     features: {
@@ -16,7 +16,7 @@ exports.testInsertFeaturesWithOneFeature = function(test) {
 };
 
 exports.testInsertFeaturesWithMultipleFeatures = function(test) {
-  var expected = '<script>TEST = {};TEST.FEATURES = {"test":true,"anotherFeature":false};TEST.FEATURES.isEnabled = function(feature) {return this[feature];};</script>';
+  var expected = 'TEST = {};TEST.FEATURES = {"test":true,"anotherFeature":false};TEST.FEATURES.isEnabled = function(feature) {return this[feature];};';
   var options = {
     namespace: 'TEST',
     features: {


### PR DESCRIPTION
The `app` type is ran inside the `my-app-name.js` file already, so does not require `<script>` tags.

See https://github.com/ember-cli/ember-cli/blob/master/lib/broccoli/app-suffix.js#L7.
