### PR TITLE
Handle namespaces with spl.operators

### DIFF
--- a/lib/insert-features.js
+++ b/lib/insert-features.js
@@ -1,8 +1,8 @@
 function featuresPrefix(namespace) {
   var prefix = [
     '(function(w) {',
-    'w.' + namespace + ' = w.' + namespace + ' || {};',
-    'w.' + namespace + '.FEATURES = {'
+    'w["' + namespace + '"] = w["' + namespace + '"] || {};',
+    'w["' + namespace + '"].FEATURES = {'
   ];
 
   return prefix.join('');
@@ -11,7 +11,7 @@ function featuresPrefix(namespace) {
 function featuresSuffix(namespace) {
   var isEnabled = function() {
     return [
-      'w.' + namespace + '.FEATURES.isEnabled = function(feature) {',
+      'w["' + namespace + '"].FEATURES.isEnabled = function(feature) {',
       'return this[feature];',
       '};',
     ].join('');

--- a/tests/insert-features-test.js
+++ b/tests/insert-features-test.js
@@ -1,7 +1,7 @@
 var insertFeatures = require('../lib/insert-features');
 
 exports.testInsertFeaturesWithOneFeature = function(test) {
-  var expected = '(function(w) {w.TEST = w.TEST || {};w.TEST.FEATURES = {"test":true};w.TEST.FEATURES.isEnabled = function(feature) {return this[feature];};})(window);';
+  var expected = '(function(w) {w["TEST"] = w["TEST"] || {};w["TEST"].FEATURES = {"test":true};w["TEST"].FEATURES.isEnabled = function(feature) {return this[feature];};})(window);';
   var options = {
     namespace: 'TEST',
     features: {
@@ -16,7 +16,7 @@ exports.testInsertFeaturesWithOneFeature = function(test) {
 };
 
 exports.testInsertFeaturesWithMultipleFeatures = function(test) {
-  var expected = '(function(w) {w.TEST = w.TEST || {};w.TEST.FEATURES = {"test":true,"anotherFeature":false};w.TEST.FEATURES.isEnabled = function(feature) {return this[feature];};})(window);';
+  var expected = '(function(w) {w["TEST"] = w["TEST"] || {};w["TEST"].FEATURES = {"test":true,"anotherFeature":false};w["TEST"].FEATURES.isEnabled = function(feature) {return this[feature];};})(window);';
   var options = {
     namespace: 'TEST',
     features: {


### PR DESCRIPTION
Ember cli handles namespaces with special operators like + - which would otherwise cause issues by using array notation as `'window["' +namespace + '"]'` . I've made the necessary changes with this PR.
