### PR TITLE
Generate helpful error when being included in older Ember CLI.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,13 @@
 
 var defeatureify = require('broccoli-defeatureify');
 var insertContent = require('./lib/insert-features');
+var checker = require('ember-cli-version-checker');
 
 module.exports = {
   name: 'ember-cli-defeatureify',
+  init: function() {
+    checker.assertAbove(this, '0.1.15');
+  },
   included: function(app) {
     this._super.included.apply(this, arguments);
     this.app = app;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "node_modules/.bin/nodeunit tests"
   },
   "dependencies": {
-    "broccoli-defeatureify": "1.0.0"
+    "broccoli-defeatureify": "1.0.0",
+    "ember-cli-version-checker": "^1.0.1"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
Will generate a warning (and exit the process) when the minimum Ember CLI version is not met:

```
The addon `ember-cli-defeatureify` requires an Ember CLI version of 0.1.15 or above, but you are running 0.1.0.
```
