### PR TITLE
Camelize namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Specify features in your project's `Brocfile.js`:
 ```js
 var app = new EmberApp({
   defeatureify: {
-    namespace: 'mynamespace',
+    namespace: 'myNamespace',
     features: {
       "propertyBraceExpansion": true,
       "ember-metal-run-bind": true,
@@ -29,12 +29,12 @@ var app = new EmberApp({
 })
 ```
 
-When building in `development`, these features will be inlined in `my-app.js`, while they're only used for defeatureifying your code when building in `production`. The features are available to you in your application code under `mynamespace.FEATURES`.
+When building in `development`, these features will be inlined in `my-app.js`, while they're only used for defeatureifying your code when building in `production`. The features are available to you in your application code under `myNamespace.FEATURES`.
 
 To use the feature flags, you would wrap the code you want to enable like this:
 
 ```js
-if(mynamespace.FEATURES.isEnabled('propertyBraceExpansion')) {
+if(myNamespace.FEATURES.isEnabled('propertyBraceExpansion')) {
   // Your code here
 } else {
   // What to do if feature is disabled
@@ -46,6 +46,15 @@ if(mynamespace.FEATURES.isEnabled('propertyBraceExpansion')) {
 ## Options
 
 ### options.namespace
-Namespace defaults to your application name from `package.json`
+Namespace defaults to your application name from `package.json`, but you can specify your own through the `namespace` option.
+
+The namespace is `camelized` if it contains dashes, underscores or spaces to make sure it's valid JavaScript and parseable by `defeatureify`.
+
+**Example**:
+```js
+'my-app-namespace'  // myAppNamespace
+'app_namespace'     // appNamespace
+'awesome namespace' // awesomeNamespace
+```
 
 See [grunt-ember-defeatureify](https://github.com/craigteegarden/grunt-ember-defeatureify#options) for more documentation of options.

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 var defeatureify = require('broccoli-defeatureify');
 var insertContent = require('./lib/insert-features');
 var checker = require('ember-cli-version-checker');
+var camelize = require('./lib/camelize');
 
 module.exports = {
   name: 'ember-cli-defeatureify',
@@ -34,6 +35,10 @@ function getOptions(app, options) {
 
   if(!options.namespace) {
     options.namespace = app.name;
+  }
+
+  if(options.namespace) {
+    options.namespace = camelize(options.namespace);
   }
 
   if(!options.features) {

--- a/lib/camelize.js
+++ b/lib/camelize.js
@@ -1,0 +1,11 @@
+var STRING_CAMELIZE_REGEXP = (/(\-|_|\.|\s)+(.)?/g);
+
+function camelize(key) {
+  return key.replace(STRING_CAMELIZE_REGEXP, function(match, separator, chr) {
+    return chr ? chr.toUpperCase() : '';
+  }).replace(/^([A-Z])/, function(match, separator, chr) {
+    return match.toLowerCase();
+  });
+}
+
+module.exports = camelize;

--- a/tests/camelize-test.js
+++ b/tests/camelize-test.js
@@ -1,0 +1,57 @@
+var camelize = require('../lib/camelize');
+
+exports.shouldCamelizeNormal = function(test) {
+  var expected = 'aNormalString';
+  var actual = camelize('a normal string');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldCamelizeCapitalized = function(test) {
+  var expected = 'aCapitalizedString';
+  var actual = camelize('A Capitalized String');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldCamelizeDashes = function(test) {
+  var expected = 'aDasherizedString';
+  var actual = camelize('a-dasherized-string');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldCamelizeDotNotation = function(test) {
+  var expected = 'dotNotation';
+  var actual = camelize('dot.notation');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldCamelizeUnderscores = function(test) {
+  var expected = 'iAmUnderscored';
+  var actual = camelize('i_am_underscored');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldIgnoreAlreadyCamelizedStrings = function(test) {
+  var expected = 'iAmCamelized';
+  var actual = camelize('iAmCamelized');
+
+  test.equal(actual, expected);
+  test.done();
+};
+
+exports.shouldIgnoreOneWordString = function(test) {
+  var expected = 'string';
+  var actual = camelize('string');
+
+  test.equal(actual, expected);
+  test.done();
+};


### PR DESCRIPTION
This makes sure the namespace is camelized before it's inserted into the DOM using the `contentFor`, and before being passed to `defeatureify` in the `postprocessTree` hook. 
