### PR TITLE
Fix #19 DEPRECATION: Overriding init without calling this._super

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ var camelize = require('./lib/camelize');
 module.exports = {
   name: 'ember-cli-defeatureify',
   init: function() {
+    this._super.init && this._super.init.apply(this, arguments);
     checker.assertAbove(this, '0.1.15');
   },
   included: function(app) {


### PR DESCRIPTION
Closes #19
